### PR TITLE
Fix README and imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,15 @@
 # jaq
 jaq is a scriptable, command-line tool for working with JSON endpoints. Get, put, filter, and print JSON to and from URLs. Take the output from one JSON endpoint, filter it, and and pipe it out to another all from the command line.
 
+[![Build Status](https://travis-ci.com/Ericsson/jaq.svg?branch=master)](https://travis-ci.com/Ericsson/jaq)
+
 ## Installation
 
 1. Clone the repo & run `go install`
 2. Setup a small config file at ~/.jaq.json:
 3. Run commands!
 ```
-go get github.com/jaq && go install
+go get github.com/Ericsson/jaq && go install
 cat '{"domain":"jsonplaceholder.typicode.com"}' > ~/.jaq.json
 jaq get /posts
 ```

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -20,7 +20,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/ericsson/jaq/transform"
+	"github.com/Ericsson/jaq/transform"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"

--- a/main.go
+++ b/main.go
@@ -14,7 +14,7 @@
 
 package main
 
-import "github.com/ericsson/jaq/cmd"
+import "github.com/Ericsson/jaq/cmd"
 
 func main() {
 	cmd.Execute()


### PR DESCRIPTION
 - The imports had the case wrong for the organization causing
CI failure.
 - Added CI status to README
 - Fixed `go get` line in README