### PR TITLE
Fix timing for loading the config

### DIFF
--- a/cmd/httpVerb.go
+++ b/cmd/httpVerb.go
@@ -313,10 +313,10 @@ func copyNewline(w io.Writer, r io.Reader, copyHeaders http.Header) (n int64, er
 }
 
 func init() {
-	manualInitHTTPVerbs()
+	ResetSettingsHTTPVerbs()
 }
 
-func manualInitHTTPVerbs() {
+func ResetSettingsHTTPVerbs() {
 	for _, cmd := range []*cobra.Command{
 		httpCommand(http.MethodGet),
 		httpCommand(http.MethodPut),

--- a/cmd/httpVerb_test.go
+++ b/cmd/httpVerb_test.go
@@ -345,7 +345,7 @@ func TestHTTPVerbs(t *testing.T) {
 			defer s.Close()
 
 			// Reset all viper/flag settings potentially loaded.
-			manualInit()
+			ResetSettings()
 			viper.Set("scheme", "http")
 			viper.Set("domain", s.Listener.Addr().String())
 			viper.Set("subdomain", "")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -112,17 +112,13 @@ func execute(args []string, pipeFrom io.Reader) error {
 	return nil
 }
 
-func init() {
-	manualInit()
-}
-
-func manualInit() {
+func ResetSettings() {
 	RootCmd.ResetCommands()
 	RootCmd.ResetFlags()
 	viper.Reset()
 
 	addFlags(RootCmd.PersistentFlags())
-	manualInitHTTPVerbs()
+	ResetSettingsHTTPVerbs()
 
 	// Explicitly loading config now so that we can get config and explode.
 	// Config is needed in order to properly load the right config file which
@@ -188,10 +184,9 @@ func initConfig(cfgFile string) {
 	viper.SetEnvKeyReplacer(replacer)
 	viper.AutomaticEnv()
 
-	// If a config file is found, read it in.
 	if err := viper.ReadInConfig(); err != nil {
 		log.Printf("Error reading config: %v", err)
 		log.Print("jaq not configured; expects either $HOME/.jaq.json or a config at the path specified via --config")
-		os.Exit(-1)
+		os.Exit(1)
 	}
 }

--- a/main.go
+++ b/main.go
@@ -17,5 +17,6 @@ package main
 import "github.com/Ericsson/jaq/cmd"
 
 func main() {
+	cmd.ResetSettings()
 	cmd.Execute()
 }


### PR DESCRIPTION
By exporting the ResetSettings method we can call it in `main()`
to get the appropriate user behavior and also get tests to pass
as expected.

Also fixed the example in the readme slightly.